### PR TITLE
docs: add link to the GitHub Actions status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# discord.js-next ![Testing](https://github.com/discordjs/discord.js-next/workflows/Testing/badge.svg?branch=master)
+# discord.js-next [![Testing](https://github.com/discordjs/discord.js-next/workflows/Testing/badge.svg?branch=master)](https://github.com/discordjs/discord.js-next/actions?query=workflow%3ATesting)
 
 ## Status: pre-alpha
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This adds a link so that clicking the GitHub Actions status badge will take you to [the Actions tab on this repository](https://github.com/discordjs/discord.js-next/actions?query=workflow%3ATesting).

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
