### PR TITLE
ci(cron): use Git checkout version 2

### DIFF
--- a/.github/workflows/test-cron.yml
+++ b/.github/workflows/test-cron.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Node v12
         uses: actions/setup-node@v1


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR will make the cron CI job use GitHub Actions Checkout v2, like the main one is using.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.