### PR TITLE
test(rest): replace usages of toEqual with toStrictEqual or toBe

### DIFF
--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -49,23 +49,23 @@ nock(`${DefaultRestOptions.api}/v${DefaultRestOptions.version}`)
 	.reply(200, { test: true });
 
 test('simple GET', async () => {
-	expect(await api.get('/simpleGet')).toEqual({ test: true });
+	expect(await api.get('/simpleGet')).toStrictEqual({ test: true });
 });
 
 test('simple DELETE', async () => {
-	expect(await api.delete('/simpleDelete')).toEqual({ test: true });
+	expect(await api.delete('/simpleDelete')).toStrictEqual({ test: true });
 });
 
 test('simple PATCH', async () => {
-	expect(await api.patch('/simplePatch')).toEqual({ test: true });
+	expect(await api.patch('/simplePatch')).toStrictEqual({ test: true });
 });
 
 test('simple PUT', async () => {
-	expect(await api.put('/simplePut')).toEqual({ test: true });
+	expect(await api.put('/simplePut')).toStrictEqual({ test: true });
 });
 
 test('simple POST', async () => {
-	expect(await api.post('/simplePost')).toEqual({ test: true });
+	expect(await api.post('/simplePost')).toStrictEqual({ test: true });
 });
 
 test('getQuery', async () => {
@@ -76,35 +76,35 @@ test('getQuery', async () => {
 				['hello', 'world'],
 			]),
 		}),
-	).toEqual({ test: true });
+	).toStrictEqual({ test: true });
 });
 
 test('getAuth default', async () => {
-	expect(await api.get('/getAuth')).toEqual({ auth: 'Bot A-Very-Fake-Token' });
+	expect(await api.get('/getAuth')).toStrictEqual({ auth: 'Bot A-Very-Fake-Token' });
 });
 
 test('getAuth unauthorized', async () => {
-	expect(await api.get('/getAuth', { auth: false })).toEqual({ auth: null });
+	expect(await api.get('/getAuth', { auth: false })).toStrictEqual({ auth: null });
 });
 
 test('getAuth authorized', async () => {
-	expect(await api.get('/getAuth', { auth: true })).toEqual({ auth: 'Bot A-Very-Fake-Token' });
+	expect(await api.get('/getAuth', { auth: true })).toStrictEqual({ auth: 'Bot A-Very-Fake-Token' });
 });
 
 test('getReason default', async () => {
-	expect(await api.get('/getReason')).toEqual({ reason: null });
+	expect(await api.get('/getReason')).toStrictEqual({ reason: null });
 });
 
 test('getReason plain text', async () => {
-	expect(await api.get('/getReason', { reason: 'Hello' })).toEqual({ reason: 'Hello' });
+	expect(await api.get('/getReason', { reason: 'Hello' })).toStrictEqual({ reason: 'Hello' });
 });
 
 test('getReason encoded', async () => {
-	expect(await api.get('/getReason', { reason: '😄' })).toEqual({ reason: '%F0%9F%98%84' });
+	expect(await api.get('/getReason', { reason: '😄' })).toStrictEqual({ reason: '%F0%9F%98%84' });
 });
 
 test('postAttachment empty', async () => {
-	expect(await api.post('/postAttachment', { attachments: [] })).toEqual({
+	expect(await api.post('/postAttachment', { attachments: [] })).toStrictEqual({
 		body: '',
 	});
 });
@@ -114,7 +114,7 @@ test('postAttachment attachment', async () => {
 		await api.post('/postAttachment', {
 			attachments: [{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') }],
 		}),
-	).toEqual({
+	).toStrictEqual({
 		body: [
 			'Content-Disposition: form-data; name="out.txt"; filename="out.txt"',
 			'Content-Type: text/plain',
@@ -130,7 +130,7 @@ test('postAttachment attachment and JSON', async () => {
 			attachments: [{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') }],
 			body: { foo: 'bar' },
 		}),
-	).toEqual({
+	).toStrictEqual({
 		body: [
 			'Content-Disposition: form-data; name="out.txt"; filename="out.txt"',
 			'Content-Type: text/plain',
@@ -144,13 +144,15 @@ test('postAttachment attachment and JSON', async () => {
 });
 
 test('postEcho', async () => {
-	expect(await api.post('/postEcho', { body: { foo: 'bar' } })).toEqual({ foo: 'bar' });
+	expect(await api.post('/postEcho', { body: { foo: 'bar' } })).toStrictEqual({ foo: 'bar' });
 });
 
 test('Old Message Delete Edge-Case: Old message', async () => {
-	expect(await api.delete(Routes.channelMessage('339942739275677727', '392063687801700356'))).toEqual({ test: true });
+	expect(await api.delete(Routes.channelMessage('339942739275677727', '392063687801700356'))).toStrictEqual({
+		test: true,
+	});
 });
 
 test('Old Message Delete Edge-Case: New message', async () => {
-	expect(await api.delete(Routes.channelMessage('339942739275677727', newSnowflake))).toEqual({ test: true });
+	expect(await api.delete(Routes.channelMessage('339942739275677727', newSnowflake))).toStrictEqual({ test: true });
 });

--- a/packages/rest/__tests__/RequestHandler.test.ts
+++ b/packages/rest/__tests__/RequestHandler.test.ts
@@ -120,11 +120,11 @@ nock(`${DefaultRestOptions.api}/v${DefaultRestOptions.version}`)
 test('Handle standard rate limits', async () => {
 	const [a, b, c] = [api.get('/standard'), api.get('/standard'), api.get('/standard')];
 
-	expect(await a).toEqual(Buffer.alloc(0));
+	expect(await a).toStrictEqual(Buffer.alloc(0));
 	const previous1 = Date.now();
-	expect(await b).toEqual(Buffer.alloc(0));
+	expect(await b).toStrictEqual(Buffer.alloc(0));
 	const previous2 = Date.now();
-	expect(await c).toEqual(Buffer.alloc(0));
+	expect(await c).toStrictEqual(Buffer.alloc(0));
 	const now = Date.now();
 	expect(previous2).toBeGreaterThanOrEqual(previous1 + 250);
 	expect(now).toBeGreaterThanOrEqual(previous2 + 250);
@@ -132,25 +132,25 @@ test('Handle standard rate limits', async () => {
 
 test('Handle global rate limits', async () => {
 	const earlier = Date.now();
-	expect(await api.get('/triggerGlobal')).toEqual({ global: true });
-	expect(await api.get('/regularRequest')).toEqual({ test: true });
+	expect(await api.get('/triggerGlobal')).toStrictEqual({ global: true });
+	expect(await api.get('/regularRequest')).toStrictEqual({ test: true });
 	expect(Date.now()).toBeGreaterThanOrEqual(earlier + 100);
 });
 
 test('Handle unexpected 429', async () => {
 	const previous = Date.now();
-	expect(await api.get('/unexpected')).toEqual({ test: true });
+	expect(await api.get('/unexpected')).toStrictEqual({ test: true });
 	expect(Date.now()).toBeGreaterThanOrEqual(previous + 1000);
 });
 
 test('Handle unexpected 429 cloudflare', async () => {
 	const previous = Date.now();
-	expect(await api.get('/unexpected-cf')).toEqual({ test: true });
+	expect(await api.get('/unexpected-cf')).toStrictEqual({ test: true });
 	expect(Date.now()).toBeGreaterThanOrEqual(previous + 1000);
 });
 
 test('Handle temp server outage', async () => {
-	expect(await api.get('/temp')).toEqual({ test: true });
+	expect(await api.get('/temp')).toStrictEqual({ test: true });
 });
 
 test('perm server outage', async () => {

--- a/packages/rest/__tests__/RequestManager.test.ts
+++ b/packages/rest/__tests__/RequestManager.test.ts
@@ -14,5 +14,5 @@ test('no token', async () => {
 test('negative offset', () => {
 	const badREST = new REST({ offset: -5000 });
 
-	expect(badREST.requestManager.options.offset).toEqual(0);
+	expect(badREST.requestManager.options.offset).toBe(0);
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Some of the tests in the REST package were using `toEqual`, which should be replaced with `toStrictEqual` or `toBe` when possible.

> `toStrictEqual` not only checks that two objects contain the same data but also that they have the same structure. It is common to expect objects to not only have identical values but also to have identical keys. A stricter equality will catch cases where two objects do not have identical keys.

In the future consider using [`eslint-plugin-jest`'s `prefer-strict-equal` rule](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-strict-equal.md) to automate this.

**Status and versioning classification:**

Only modifies tests, the version should not be changed.
