### PR TITLE
chore(Rest): remove `/core` dependency

### DIFF
--- a/packages/core/__tests__/index.test.ts
+++ b/packages/core/__tests__/index.test.ts
@@ -1,7 +1,0 @@
-import { sleep } from '../src';
-
-test('sleep', async () => {
-	const before = Date.now();
-	await sleep(100);
-	expect(Date.now() - before).toBeGreaterThanOrEqual(100);
-});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
 	"engines": {
 		"node": ">=16.0.0"
 	},
+	"private": true,
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,0 @@
-export function sleep(ms: number) {
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -40,7 +40,6 @@
 	],
 	"dependencies": {
 		"@discordjs/collection": "^0.1.6",
-		"@discordjs/core": "^0.0.0",
 		"@sapphire/async-queue": "^1.1.4",
 		"@sapphire/snowflake": "^1.3.5",
 		"abort-controller": "^3.0.0",

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -1,4 +1,4 @@
-import { sleep } from '@discordjs/core';
+import { setTimeout as sleep } from 'timers/promises';
 import { AsyncQueue } from '@sapphire/async-queue';
 import AbortController from 'abort-controller';
 import fetch, { RequestInit, Response } from 'node-fetch';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since we're using Node.js v16 now, we can use `timers/promises` over `util.promisify(setTimeout)`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
